### PR TITLE
Qualification and out params

### DIFF
--- a/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
+++ b/ICSharpCode.CodeConverter/CSharp/CompilationErrorFixer.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace ICSharpCode.CodeConverter.CSharp
+{
+	internal class CompilationErrorFixer
+	{
+		private readonly CSharpSyntaxTree syntaxTree;
+		private readonly SemanticModel semanticModel;
+
+		public CompilationErrorFixer(CSharpCompilation compilation, CSharpSyntaxTree syntaxTree)
+		{
+			this.syntaxTree = syntaxTree;
+			this.semanticModel = compilation.GetSemanticModel(syntaxTree, true);
+		}
+
+		public CSharpSyntaxNode Fix()
+		{
+			var syntaxNode = syntaxTree.GetRoot();
+			return syntaxNode.ReplaceNodes(syntaxNode.DescendantNodes(), ComputeReplacementNode);
+		}
+
+		private SyntaxNode ComputeReplacementNode(SyntaxNode originalNode, SyntaxNode potentiallyRewrittenNode)
+		{
+			if (!(potentiallyRewrittenNode is ArgumentListSyntax nodeToReturn)) return potentiallyRewrittenNode;
+
+			var invocationExpression = nodeToReturn.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+			if (invocationExpression == null) return potentiallyRewrittenNode;
+
+			var methodSymbol = semanticModel.GetSymbolInfo(invocationExpression).CandidateSymbols.OfType<IMethodSymbol>()
+				.FirstOrDefault(s => invocationExpression.ArgumentList.Arguments.Count == s.Parameters.Length);
+			if (methodSymbol != null) {
+				//Won't work for named parameters
+				for (var index = 0; index < Math.Min(nodeToReturn.Arguments.Count, methodSymbol.Parameters.Length); index++) {
+					var argument = nodeToReturn.Arguments[index];
+					var refOrOutKeyword = GetRefKeyword(methodSymbol.Parameters[index]);
+					var currentSyntaxKind = nodeToReturn.Arguments[index].Kind();
+					if (!refOrOutKeyword.IsKind(currentSyntaxKind)) {
+						nodeToReturn = nodeToReturn.ReplaceNode(argument,
+							SyntaxFactory.Argument(argument.NameColon, refOrOutKeyword, argument.Expression)
+								.WithLeadingTrivia(argument.GetLeadingTrivia())
+								.WithTrailingTrivia(argument.GetTrailingTrivia()));
+					}
+				}
+			}
+			return nodeToReturn;
+		}
+
+		private static SyntaxToken GetRefKeyword(IParameterSymbol formalParameter)
+		{
+			SyntaxToken token;
+			switch (formalParameter.RefKind) {
+				case RefKind.None:
+					token = default(SyntaxToken);
+					break;
+				case RefKind.Ref:
+					token = SyntaxFactory.Token(SyntaxKind.RefKeyword);
+					break;
+				case RefKind.Out:
+					token = SyntaxFactory.Token(SyntaxKind.OutKeyword);
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+			return token.WithTrailingTrivia(SyntaxFactory.Whitespace(" "));
+		}
+	}
+}

--- a/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/MethodBodyVisitor.cs
@@ -43,10 +43,10 @@ namespace ICSharpCode.CodeConverter.CSharp
 
 			public override SyntaxList<StatementSyntax> VisitStopOrEndStatement(VBSyntax.StopOrEndStatementSyntax node)
 			{
-				return SingleStatement(SyntaxFactory.ParseStatement(GetCSharpEquivalentStatementText(node)));
+				return SingleStatement(SyntaxFactory.ParseStatement(ConvertStopOrEndToCSharpStatementText(node)));
 			}
 
-			private static string GetCSharpEquivalentStatementText(VBSyntax.StopOrEndStatementSyntax node)
+			private static string ConvertStopOrEndToCSharpStatementText(VBSyntax.StopOrEndStatementSyntax node)
 			{
 				switch (VBasic.VisualBasicExtensions.Kind(node.StopOrEndKeyword)) {
 					case VBasic.SyntaxKind.StopKeyword:
@@ -73,10 +73,22 @@ namespace ICSharpCode.CodeConverter.CSharp
 
 			public override SyntaxList<StatementSyntax> VisitAddRemoveHandlerStatement(VBSyntax.AddRemoveHandlerStatementSyntax node)
 			{
-				var syntaxKind = node.Kind() == VBasic.SyntaxKind.AddHandlerStatement ? SyntaxKind.AddAssignmentExpression : SyntaxKind.SubtractAssignmentExpression;
+				var syntaxKind = ConvertAddRemoveHandlerToCSharpSyntaxKind(node);
 				return SingleStatement(SyntaxFactory.AssignmentExpression(syntaxKind,
 					(ExpressionSyntax)node.EventExpression.Accept(nodesVisitor),
 					(ExpressionSyntax)node.DelegateExpression.Accept(nodesVisitor)));
+			}
+
+			private static SyntaxKind ConvertAddRemoveHandlerToCSharpSyntaxKind(VBSyntax.AddRemoveHandlerStatementSyntax node)
+			{
+				switch (node.Kind()) {
+					case VBasic.SyntaxKind.AddHandlerStatement:
+						return SyntaxKind.AddAssignmentExpression;
+					case VBasic.SyntaxKind.RemoveHandlerStatement:
+						return SyntaxKind.SubtractAssignmentExpression;
+					default:
+						throw new NotImplementedException(node.Kind() + " not implemented!");
+				}
 			}
 
 			public override SyntaxList<StatementSyntax> VisitExpressionStatement(VBSyntax.ExpressionStatementSyntax node)

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -38,16 +38,14 @@ namespace ICSharpCode.CodeConverter.CSharp
 		class NodesVisitor : VBasic.VisualBasicSyntaxVisitor<CSharpSyntaxNode>
 		{
 			private SemanticModel semanticModel;
-			private Document targetDocument;
 			private readonly Dictionary<ITypeSymbol, string> createConvertMethodsLookupByReturnType;
 			private readonly Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax[]> additionalDeclarations = new Dictionary<MemberDeclarationSyntax, MemberDeclarationSyntax[]>();
 			private readonly Stack<string> withBlockTempVariableNames = new Stack<string>();
 			readonly IDictionary<string, string> importedNamespaces;
 
-			public NodesVisitor(SemanticModel semanticModel, Document targetDocument)
+			public NodesVisitor(SemanticModel semanticModel)
 			{
 				this.semanticModel = semanticModel;
-				this.targetDocument = targetDocument;
 				importedNamespaces = new Dictionary<string, string> {{VBasic.VisualBasicExtensions.RootNamespace(semanticModel.Compilation).ToString(), ""}};
 				this.createConvertMethodsLookupByReturnType = CreateConvertMethodsLookupByReturnType(semanticModel);
 			}

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1223,7 +1223,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 						qualifiedName = qualifiedName.Substring(typeOrNamespace.Length + 1);
 					}
 				}
-				return qualifiedName.ToString() != defaultNode.ToString() ? 
+				return qualifiedName != defaultNode.ToString() ? 
 					SyntaxFactory.ParseName(qualifiedName.Replace(node.ToString(), defaultNode.ToString()))
 					: defaultNode;
 			}

--- a/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
+++ b/ICSharpCode.CodeConverter/CSharp/NodesVisitor.cs
@@ -1207,8 +1207,7 @@ namespace ICSharpCode.CodeConverter.CSharp
 				var typeBlockSyntax = node.GetAncestor<VBSyntax.TypeBlockSyntax>();
 
 				var typeOrNamespace = targetSymbolInfo.ContainingNamespace.ToDisplayString(referenceSymbolFormat);
-				if (typeBlockSyntax != null)
-				{
+				if (typeBlockSyntax != null) {
 					var declaredSymbol = semanticModel.GetDeclaredSymbol(typeBlockSyntax);
 					var prefixes = GetSymbolQualification(declaredSymbol)
 					.Where(x => x != null).Select(p => p.ToDisplayString(referenceSymbolFormat) + ".");

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -222,6 +222,31 @@ class TestClass
 		}
 
 		[Fact]
+        public void ExternalReferenceToOutParameter()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Private Sub TestMethod(ByVal str As String)
+        Dim d = New Dictionary(Of string, string)
+        Dim s As String
+        d.TryGetValue(""a"", s)
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    private void TestMethod(string str)
+    {
+        var d = new Dictionary<string, string>();
+        string s;
+        d.TryGetValue(""a"", out s);
+    }
+}");
+        }
+
+        [Fact]
 		public void ElvisOperatorExpression()
 		{
 			TestConversionVisualBasicToCSharp(@"Class TestClass

--- a/Tests/CSharp/ExpressionTests.cs
+++ b/Tests/CSharp/ExpressionTests.cs
@@ -595,5 +595,47 @@ End Sub", @"public void Linq103()
     }
 }");
 		}
+
+        [Fact]
+        public void PartiallyQualifiedName()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Public Function TestMethod(dir As String) As String
+         Return IO.Path.Combine(dir, ""file.txt"")
+    End Function
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    public string TestMethod(string dir)
+    {
+        return System.IO.Path.Combine(dir, ""file.txt"");
+    }
+}");
+        }
+
+        [Fact]
+        public void UsingGlobalImport()
+        {
+            TestConversionVisualBasicToCSharp(@"Class TestClass
+    Public Function TestMethod() As String
+         Return vbCrLf
+    End Function
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class TestClass
+{
+    public string TestMethod()
+    {
+        return Constants.vbCrLf;
+    }
+}");
+        }
 	}
 }

--- a/Tests/CSharp/MemberTests.cs
+++ b/Tests/CSharp/MemberTests.cs
@@ -532,6 +532,63 @@ class TestClass
 }");
 		}
 
+        [Fact]
+        public void NestedClass()
+        {
+            TestConversionVisualBasicToCSharp(@"Class ClA
+    Public Shared Sub MA()
+        ClA.ClassB.MB()
+        MyClassC.MC()
+    End Sub
+
+    Public Class ClassB
+        Public Shared Function MB() as ClassB
+            ClA.MA()
+            MyClassC.MC()
+            Return ClA.ClassB.MB()
+        End Function
+    End Class
+End Class
+
+Class MyClassC
+    Public Shared Sub MC()
+        ClA.MA()
+        ClA.ClassB.MB()
+    End Sub
+End Class", @"using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualBasic;
+
+class ClA
+{
+    public static void MA()
+    {
+        ClA.ClassB.MB();
+        MyClassC.MC();
+    }
+
+    public class ClassB
+    {
+        public static ClassB MB()
+        {
+            ClA.MA();
+            MyClassC.MC();
+            return ClA.ClassB.MB();
+        }
+    }
+}
+
+class MyClassC
+{
+    public static void MC()
+    {
+        ClA.MA();
+        ClA.ClassB.MB();
+    }
+}");
+        }
+
 		[Fact(Skip = "Not implemented!")]
 		public void TestIndexer()
 		{

--- a/Tests/ConverterTestBase.cs
+++ b/Tests/ConverterTestBase.cs
@@ -263,7 +263,7 @@ namespace CodeConverter.Tests
 
 		CSharpSyntaxNode Convert(VisualBasicSyntaxNode input, SemanticModel semanticModel, Document targetDocument)
 		{
-			return VisualBasicConverter.Convert(input, semanticModel, targetDocument);
+			return VisualBasicConverter.ConvertSingle((VisualBasicCompilation) semanticModel.Compilation, (VisualBasicSyntaxTree) input.SyntaxTree);
 		}
 	}
 }


### PR DESCRIPTION
Whenever the invoked method is outside the converted code (e.g. `Dictionary<,>.TryGetValue`) it ends up as a ref instead. This fixes that problem